### PR TITLE
Production Release: Auth Service v0.0.1

### DIFF
--- a/papikos-app/values.yaml
+++ b/papikos-app/values.yaml
@@ -5,15 +5,12 @@ global:
   imageRegistry: asia-southeast1-docker.pkg.dev/belajar-kube-457207/papikos-repository
   # Default image pull policy
   imagePullPolicy: Always
-
 ingress:
   annotations: {}
   # nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-
 serviceAccount:
   create: false
   name: "default"
-
 frontend:
   image:
     repository: asia-southeast1-docker.pkg.dev/belajar-kube-457207/papikos-repository/papikos-fe
@@ -29,11 +26,10 @@ frontend:
     # - hosts:
     #   - papikos.shop
     #   secretName: papikos-shop-tls
-
 auth:
   image:
     repository: asia-southeast1-docker.pkg.dev/belajar-kube-457207/papikos-repository/papikos-auth
-    tag: latest  # This will be automatically updated by CI/CD
+    tag: v0.0.1 # This will be automatically updated by CI/CD
     imagePullPolicy: Always
   service:
     name: auth
@@ -45,7 +41,6 @@ auth:
     # - hosts:
     #   - auth.papikos.shop
     #   secretName: auth-papikos-shop-tls
-  
   # Database configuration from Kubernetes Secret
   dbConfig:
     enabled: true
@@ -63,11 +58,9 @@ auth:
         envName: DATABASE_NAME
     # mountAllKeysFromSecret: "auth-database-credentials"
     # Note: If using mountAllKeysFromSecret, envMappings above would typically be commented out or removed.
-
 # Version tracking (for reference)
 version:
-  auth: latest  # Current deployed version
-  frontend: latest  # Current deployed version
-  lastUpdated: ""  # Timestamp of last update
-  deployedBy: ""  # Who triggered the deployment
-
+  auth: latest # Current deployed version
+  frontend: latest # Current deployed version
+  lastUpdated: "" # Timestamp of last update
+  deployedBy: "" # Who triggered the deployment


### PR DESCRIPTION
## Production Release: Auth Service v0.0.1

This PR updates the auth service for production deployment.

**Changes:**
- Auth service image tag: `v0.0.1`
- Source repository: AdvProg-B15/papikos-auth
- Source commit: [`fb499726435d077cf9a25fdaa8e42a5d103e02bc`](https://github.com/AdvProg-B15/papikos-auth/commit/fb499726435d077cf9a25fdaa8e42a5d103e02bc)
- Build run: [5](https://github.com/AdvProg-B15/papikos-auth/actions/runs/15205203073)

**Build Information:**
- Image: `asia-southeast1-docker.pkg.dev/belajar-kube-457207/papikos-repository/papikos-auth:v0.0.1`
- Platform: `linux/amd64`
- Built at: `2025-05-23T14:48:46+07:00`

**Production Deployment**
Please review carefully before merging. ArgoCD will automatically deploy once merged.

**Pre-deployment Checklist:**
- [x] Image built successfully
- [x] Image pushed to registry
- [ ] Security review completed
- [ ] Breaking changes reviewed
- [ ] Ready for production deployment

**Rollback Plan:**
If issues occur, you can quickly rollback by reverting this PR or updating the image tag manually.